### PR TITLE
Super simple solution to fix the camera flickering

### DIFF
--- a/ValheimVRM/VRMEyePositionSync.cs
+++ b/ValheimVRM/VRMEyePositionSync.cs
@@ -27,7 +27,7 @@ namespace ValheimVRM
             }
         }
 
-        void Update()
+        void LateUpdate()
         {
             // Check if orgEye is not null before accessing its position
             if (orgEye != null)


### PR DESCRIPTION
The issue stems from the m_eye position and the VRM eye position being out of sync by one frame due to a race condition. Moving the final update to a LateUpdate() resolves the issue.